### PR TITLE
add date_of_birth cleaning rule for oscar bad date value

### DIFF
--- a/jobs/V2/f2-j2-upsertCasesToPrimero.js
+++ b/jobs/V2/f2-j2-upsertCasesToPrimero.js
@@ -364,6 +364,10 @@ fn(state => {
 
     const referralReason = c.reason_for_referral;
 
+    //cleaning rule for date_of_birth when Oscar sometimes sends bad date value e.g., 22012-01-01
+    const dob = c.date_of_birth;
+    const cleanedDob = dob && dob.length === 11 ? dob.substring(1, 11) : dob;
+
     return {
       __original_oscar_record: c,
       oscar_number: c.global_id,
@@ -374,8 +378,8 @@ fn(state => {
       name_first: isUpdate ? undefined : createName(c.given_name, c.local_given_name),
       name_last: isUpdate ? undefined : createName(c.family_name, c.local_family_name),
       sex: isUpdate ? undefined : setGender(c.gender),
-      age: isUpdate ? undefined : calcAge(c.date_of_birth),
-      date_of_birth: isUpdate ? undefined : c.date_of_birth,
+      age: isUpdate ? undefined : calcAge(cleanedDob),
+      date_of_birth: isUpdate ? undefined : cleanedDob,
       location_current: isUpdate ? undefined : locationCode,
       oscar_status: c.status,
       protection_status: !isUpdate && c.is_referred == true ? 'oscar_referral' : undefined,


### PR DESCRIPTION
OSCaR is sometimes sending a bad `date_of_birth` value with 11 characters e.g., `22012-01-01`. We want to automate cleaning this to return `2012-01-01`. 