### PR TITLE
fixes issue where Primero  query issue when `workflow` field does not indicate new referral

### DIFF
--- a/jobs/V2/f1-j1-getPrimeroCasesV2.js
+++ b/jobs/V2/f1-j1-getPrimeroCasesV2.js
@@ -20,6 +20,8 @@ getCases(
   {
     remote: true,
     last_updated_at: state => `${state.cursor}..`,
+    page: 1,
+    per: 10000,
     // These cases have been recently updated and MIGHT have a new referral to send to Oscar; we check & filter below
     // workflow: 'referral_to_oscar', //REMOVED July '23 bc we should rely on services, not case-level statuses
   },
@@ -70,6 +72,8 @@ getCases(
   {
     remote: true,
     last_updated_at: state => `${state.cursor}..`,
+    page: 1,
+    per: 10000,
     //workflow: 'referral_from_oscar', //REMOVED July '23 bc we should rely on services, not case-level statuses
     // These cases have a service that might have a decision to send back to Oscar
   },
@@ -106,6 +110,8 @@ getCases(
   {
     remote: true,
     last_updated_at: state => `${state.cursor}..`,
+    page: 1,
+    per: 10000,
   },
   { withReferrals: true },
   state => {

--- a/jobs/V2/f2-j2-upsertCasesToPrimero.js
+++ b/jobs/V2/f2-j2-upsertCasesToPrimero.js
@@ -68,21 +68,23 @@ fn(state => {
   }
 
   function setProvinceUser(c) {
-    const { location_current_village_code, organization_address_code } = c;
+    const { location_current_village_code, organization_address_code, external_id, global_id } = c;
     const source = location_current_village_code || organization_address_code;
-    //console.log('Location code sent by Oscar :: ', source);
+    console.log('Finding province user for this case from Oscar... id: ', global_id);
+    console.log('Primero case id (if case already synced) :: ', external_id);
+    console.log('Location code sent by Oscar :: ', source);
     if (source) {
       //If Village (admin level 4 location) not specified in OSCaR, then we expect a shorter location code and sometimes it has leading 0s (e.g., '0004')
       //This logic therefore tells us how to extract the province code from the full location code
       //Depending on the length of the location code and if leading 0s, we may need to look in a different spot for the province code
       const subCode = source.slice(0, 2) === '00' ? source.slice(2, 4) : source.slice(0, 2);
-      //console.log('Matching province code:: ', subCode);
-      user = provinceUserMap[subCode];
-      //console.log('Province username located:: ', user);
+      console.log('Matching Primero province code:: ', subCode);
+      const user = provinceUserMap[subCode];
+      console.log('Primero province username located:: ', user);
       if (user) {
         return user;
       } else {
-        throw 'Province user not found for this case. Check the case location and list of available province users.';
+        throw `Province user not found for this case ${global_id} with Oscar location code ${source}. Verify the case location and mapping to Primero province users.`;
       }
     } else {
       return null;


### PR DESCRIPTION
Historically, we relied on the Primero case field `workflow` to indicate when a new referral was ready to be sent to the Oscar system via OpenFn. In July 2023, UNICEF confirmed that this field was not reliable to use as a query filter, because sometimes the `workflow` status might != `refer_to_oscar`, and yet there might be a referral --> therefore a change in the OpenFn `getCases()` Primero query was decided. 

This change further addresses the related issue where OpenFn sometimes is not correctly getting all new referrals for Oscar if the `service_implemented_on` fields are populated on the service form. With this change, OpenFn should now get ALL `pending` referrals for Oscar, regardless of the case's `workflow` status and `service_implemented_on` fields. 

Also includes handling for Primero API paging and minor error-handling/ console.log improvements. 